### PR TITLE
Filling in missing techs for uncivs

### DIFF
--- a/ANSWR/history/countries/AMA - Amazona.txt
+++ b/ANSWR/history/countries/AMA - Amazona.txt
@@ -55,3 +55,6 @@ land_reform = yes_land_reform
 foreign_weapons = yes_foreign_weapons
 foreign_training = yes_foreign_training
 finance_reform = finance_reform_two
+
+# Technologies
+flintlock_rifles = 1

--- a/ANSWR/history/countries/CSK - Cusco.txt
+++ b/ANSWR/history/countries/CSK - Cusco.txt
@@ -58,3 +58,7 @@ transport_improv = yes_transport_improv
 #Starting Consciousness
 consciousness = 1
 
+# Technologies
+clipper_design = 1
+steamers = 1
+experimental_railroad = 1

--- a/ANSWR/history/countries/ELS - El Salvador.txt
+++ b/ANSWR/history/countries/ELS - El Salvador.txt
@@ -53,3 +53,8 @@ set_country_flag = new_world_nation
 foreign_weapons = yes_foreign_weapons
 military_constructions = yes_military_constructions
 firearms_production = yes_firearms_production
+
+# Technologies
+flintlock_rifles = 1
+post_napoleonic_thought = 1
+guild_based_production = 1

--- a/ANSWR/history/countries/GUA - Guatemala.txt
+++ b/ANSWR/history/countries/GUA - Guatemala.txt
@@ -53,3 +53,7 @@ naval_schools = yes_naval_schools
 foreign_weapons = yes_foreign_weapons
 military_constructions = yes_military_constructions
 education_reform = yes_education_reform
+
+# Technologies
+flintlock_rifles = 1
+post_napoleonic_thought = 1

--- a/ANSWR/history/countries/PAW - Pawnee.txt
+++ b/ANSWR/history/countries/PAW - Pawnee.txt
@@ -57,4 +57,10 @@ army_schools = yes_army_schools
 military_constructions = yes_military_constructions
 foreign_artillery = yes_foreign_artillery
 
+# Technologies
+flintlock_rifles = 1
+post_napoleonic_thought = 1
+military_staff_system = 1
+bronze_muzzle_loaded_artillery = 1
+
 oob = "PAW_oob.txt"

--- a/ANSWR/history/countries/PNM - Panama.txt
+++ b/ANSWR/history/countries/PNM - Panama.txt
@@ -54,3 +54,7 @@ firearms_production = yes_firearms_production
 pre_indust = yes_pre_indust
 industrial_construction = yes_industrial_construction
 land_reform = yes_land_reform
+
+# Technologies
+guild_based_production = 1
+piston_steam_engine = 1

--- a/ANSWR/history/countries/STR - Setjer.txt
+++ b/ANSWR/history/countries/STR - Setjer.txt
@@ -52,3 +52,6 @@ nonstate_consciousness = 1
 
 firearms_production = yes_firearms_production
 land_reform = yes_land_reform
+
+# Technologies
+guild_based_production = 1

--- a/ANSWR/history/countries/WKK - Washington Occult.txt
+++ b/ANSWR/history/countries/WKK - Washington Occult.txt
@@ -56,3 +56,6 @@ naval_schools = yes_naval_schools
 land_reform = yes_land_reform
 
 set_country_flag = new_world_nation
+
+# Technologies
+late_enlightenment_philosophy = 1

--- a/ANSWR/history/countries/YUC - Yucatan.txt
+++ b/ANSWR/history/countries/YUC - Yucatan.txt
@@ -57,3 +57,7 @@ military_constructions = yes_military_constructions
 education_reform = yes_education_reform
 land_reform = yes_land_reform
 admin_reform = yes_admin_reform
+
+# Technologies
+flintlock_rifles = 1
+post_napoleonic_thought = 1

--- a/ANSWR/history/countries/ZVY - Zelenvody.txt
+++ b/ANSWR/history/countries/ZVY - Zelenvody.txt
@@ -53,3 +53,6 @@ nonstate_consciousness = 1
 
 industrial_construction = yes_industrial_construction
 land_reform = yes_land_reform
+
+# Technologies
+piston_steam_engine = 1


### PR DESCRIPTION
When I selected Pawnee Empire I noticed that they have reforms, but have no techs. There should be at least two techs that would let to build infantry and artillery. But they are missing in the countries history file. There are some other uncivs with the same issue.
<img width="312" height="449" alt="изображение" src="https://github.com/user-attachments/assets/e42449f4-df9d-4794-b4ac-cacdecd26cde" />
<img width="998" height="367" alt="изображение" src="https://github.com/user-attachments/assets/d332bac1-5882-4c5f-8d94-a5bf633191c0" />
